### PR TITLE
Observe python exception`s standard

### DIFF
--- a/peeweext/validation.py
+++ b/peeweext/validation.py
@@ -3,7 +3,7 @@ import re
 import functools
 
 
-class ValidationError(BaseException):
+class ValidationError(Exception):
     pass
 
 


### PR DESCRIPTION
根据标准文档，自定义错误应该继承`Exception` 而不是 [BaseException](https://docs.python.org/3/library/exceptions.html#BaseException)

比如在flask框架中使用errorhandler，会触发这个异常
```
INTERNALERROR>   File "/Users/wumingyu/.virtualenvs/nest/lib/python3.6/site-packages/flask/app.py", line 1278, in _get_exc_class_and_code
INTERNALERROR>     assert issubclass(exc_class, Exception)
INTERNALERROR> AssertionError
```