### PR TITLE
Add a forwarding method to self.database

### DIFF
--- a/peeweext/sea.py
+++ b/peeweext/sea.py
@@ -45,7 +45,9 @@ class Peeweext:
                 lambda *arg, **kw: self.close_db(), weak=False)
         except ImportError:
             pass
-
+    
+    def __getattr__(self, item):
+        return getattr(self.database, item)
 
 class PeeweextMiddleware(BaseMiddleware):
     def __init__(self, app, handler, origin_handler):


### PR DESCRIPTION
起因：
在sea中使用peeweext时，`with self._db.atomic():`这一代码遇到如下问题：

```
'Peeweext' object has no attribute 'atomic'
```
`self._db`是sea项目内使用peeweext插件实例话的db对象，使用db.atomic()操作时并没有转发到peewee的db对象上，因此给peeweext的self.database添加一个转发方法
